### PR TITLE
Change API endpoints

### DIFF
--- a/components/Discovery.js
+++ b/components/Discovery.js
@@ -5,7 +5,7 @@ import {WalletUtils} from "@onflow/fcl"
 import {gte as isGreaterThanOrEqualToVersion} from "semver"
 import {useFCL} from "../hooks/useFCL"
 import {combineServices, serviceListOfType} from "../helpers/services"
-import {SERVICE_TYPES} from "../helpers/constants"
+import {PATHS, SERVICE_TYPES} from "../helpers/constants"
 import Header from "./Header"
 import Footer from "./Footer"
 import ServiceCard from "./ServiceCard"
@@ -74,7 +74,7 @@ const ProviderCardDisabled = styled.div`
 const fetcher = url => fetch(url).then(res => res.json())
 
 export const Discovery = ({network, handleCancel}) => {
-  const requestUrl = `/api/services?network=${network}`
+  const requestUrl = `/api${PATHS[network]}`
   const supportedVersion = "0.0.79" // Version that supports browser extension redirects
   const {appVersion, extensions} = useFCL()
   const {data, error} = useSWR(requestUrl, fetcher)

--- a/helpers/__tests__/paths.test.js
+++ b/helpers/__tests__/paths.test.js
@@ -1,4 +1,4 @@
-import {createPathFromArray} from "../paths"
+import {createPathFromArray, isValidPath, getNetworkFromPath} from "../paths"
 
 describe("paths helpers: createPathFromArray", () => {
   it("should create paths from array of directories", () => {
@@ -13,5 +13,31 @@ describe("paths helpers: createPathFromArray", () => {
     expect(createPathFromArray(arrOne)).toEqual(expectedResponseOne)
     expect(createPathFromArray(arrTwo)).toEqual(expectedResponseTwo)
     expect(createPathFromArray(arrThree)).toEqual(expectedResponseThree)
+  })
+})
+
+describe("paths helpers: isValidPath", () => {
+  it("should check a path is valid", () => {
+    const pathOne = ["authn"]
+    const pathTwo = ["testnet", "authn"]
+    const pathThree = ["canarynet", "authn"]
+    const pathFour = ["foo", "bar"]
+
+    expect(isValidPath(pathOne)).toBe(true)
+    expect(isValidPath(pathTwo)).toBe(true)
+    expect(isValidPath(pathThree)).toBe(true)
+    expect(isValidPath(pathFour)).toBe(false)
+  })
+})
+
+describe("paths helpers: getNetworkFromPath", () => {
+  it("should check a path is valid", () => {
+    const pathOne = ["authn"]
+    const pathTwo = ["testnet", "authn"]
+    const pathThree = ["canarynet", "authn"]
+
+    expect(getNetworkFromPath(pathOne)).toEqual("mainnet")
+    expect(getNetworkFromPath(pathTwo)).toEqual("testnet")
+    expect(getNetworkFromPath(pathThree)).toEqual("canarynet")
   })
 })

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,7 +1,7 @@
 export const PATHS = {
-  MAIN: "/authn",
-  TESTNET: "/testnet/authn",
-  CANARYNET: "/canarynet/authn",
+  mainnet: "/authn",
+  testnet: "/testnet/authn",
+  canarynet: "/canarynet/authn",
 }
 
 export const SERVICE_TYPES = {

--- a/helpers/paths.js
+++ b/helpers/paths.js
@@ -1,1 +1,10 @@
-export const createPathFromArray = (arr = []) => `/${arr.join("/")}`
+import {PATHS} from "./constants"
+
+export const createPathFromArray = (arr = []) => `/${arr.join("/")}`.toLowerCase()
+
+export const isValidPath = path => {
+  const pathStr = createPathFromArray(path)
+  return Object.values(PATHS).some(p => p === pathStr)
+}
+
+export const getNetworkFromPath = path => path && path.length === 2 ? path[0].toLowerCase() : "mainnet"

--- a/pages/[...path].js
+++ b/pages/[...path].js
@@ -1,8 +1,7 @@
 import {useRouter} from "next/router"
 import styled, {css} from "styled-components"
 import {Discovery} from "../components/Discovery"
-import {PATHS} from "../helpers/constants"
-import {createPathFromArray} from "../helpers/paths"
+import {isValidPath, getNetworkFromPath} from "../helpers/paths"
 
 const AppContainer = styled.div`
   max-height: 0;
@@ -18,15 +17,14 @@ const AppContainer = styled.div`
 const Router = ({handleCancel}) => {
   const router = useRouter()
   const {path} = router.query // ['authn'] ['testnet', 'authn'] ['canarynet', 'authn']
-  const pathStr = createPathFromArray(path)
-  const isValidRoute = Object.values(PATHS).some(p => p === pathStr)
-  const network = path && path.length === 2 ? path[0] : "mainnet"
+  const isValid = isValidPath(path)
+  const network = getNetworkFromPath(path)
 
   return (
     <AppContainer isSet={Boolean(path)}>
       {!path && <div />}
-      {path && !isValidRoute && <div>Page Not Found</div>}
-      {path && isValidRoute && (
+      {path && !isValid && <div>Page Not Found</div>}
+      {path && isValid && (
         <Discovery network={network} handleCancel={handleCancel} />
       )}
     </AppContainer>

--- a/pages/api/[...slug].js
+++ b/pages/api/[...slug].js
@@ -1,6 +1,7 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import Cors from "cors"
 import servicesJson from "../../data/services.json"
+import {isValidPath, getNetworkFromPath} from "../../helpers/paths"
 
 // Initializing the cors middleware
 const cors = Cors({
@@ -24,12 +25,12 @@ function runMiddleware(req, res, fn) {
 export default async function handler(req, res) {
   await runMiddleware(req, res, cors)
 
-  const {network} = req.query
-  const validNetworks = ["mainnet", "testnet", "canarynet"]
-  const networkStr = (network || "mainnet").toLowerCase()
-  const services = servicesJson[networkStr]
+  const slug = req.query.slug
+  const isValid = isValidPath(slug)
+  const network = getNetworkFromPath(slug)
+  const services = servicesJson[network]
 
-  if (!validNetworks.includes(networkStr)) {
+  if (!isValid) {
     return res.status(400).json({message: "Invalid Network"})
   }
 


### PR DESCRIPTION
Currently the endpoints take a network param like this:

```
/api/services?network=testnet
```

This won't be ideal when setting them in an app's FCL config. Instead, let's follow the same path as the discovery wallet with the api param addition so the routes for api use are now the following:

```
/api/authn
/api/testnet/authn
/api/canarynet/authn
```