### PR TITLE
Support filtering version

### DIFF
--- a/components/Discovery.js
+++ b/components/Discovery.js
@@ -5,7 +5,7 @@ import {WalletUtils} from "@onflow/fcl"
 import {gte as isGreaterThanOrEqualToVersion} from "semver"
 import {useFCL} from "../hooks/useFCL"
 import {combineServices, serviceListOfType} from "../helpers/services"
-import {PATHS, SERVICE_TYPES} from "../helpers/constants"
+import {PATHS, SERVICE_TYPES, SUPPORTED_VERSIONS} from "../helpers/constants"
 import Header from "./Header"
 import Footer from "./Footer"
 import ServiceCard from "./ServiceCard"
@@ -75,7 +75,6 @@ const fetcher = url => fetch(url).then(res => res.json())
 
 export const Discovery = ({network, queryStr, handleCancel}) => {
   const requestUrl = `/api${PATHS[network]}${queryStr}`
-  const supportedVersion = "0.0.79" // Version that supports browser extension redirects
   const {appVersion, extensions} = useFCL()
   const {data, error} = useSWR(requestUrl, fetcher)
   const services = useMemo(() => {
@@ -84,7 +83,7 @@ export const Discovery = ({network, queryStr, handleCancel}) => {
     // Check version of FCL. If their app version is older than the supported version for browser extensions then continue on without adding browser extensions.
     if (
       appVersion &&
-      isGreaterThanOrEqualToVersion(appVersion, supportedVersion)
+      isGreaterThanOrEqualToVersion(appVersion, SUPPORTED_VERSIONS.EXTENSIONS)
     ) {
       // Add browser extensions
       const combinedServiceList = combineServices(
@@ -108,7 +107,7 @@ export const Discovery = ({network, queryStr, handleCancel}) => {
 
     if (
       appVersion &&
-      isGreaterThanOrEqualToVersion(appVersion, supportedVersion)
+      isGreaterThanOrEqualToVersion(appVersion, SUPPORTED_VERSIONS.EXTENSIONS)
     ) {
       WalletUtils.redirect(service)
     } else {

--- a/helpers/__tests__/services.test.js
+++ b/helpers/__tests__/services.test.js
@@ -108,9 +108,21 @@ describe("services helpers: filterOptInServices", () => {
 describe("constructApiQueryParams", () => {
   it("it should construct API query params", () => {
     const filters = {
+      version: "0.0.78",
       include: ["0x1", "0x2"]
     }
 
-    expect(constructApiQueryParams(filters)).toEqual("?include=0x1&include=0x2")
+    expect(constructApiQueryParams(filters)).toEqual("?fcl_version=0.0.78&include=0x1&include=0x2")
+  })
+
+  it("it should return an empty string if nothing to construct", () => {
+    const filters = {
+      include: []
+    }
+
+    const filtersTwo = {}
+
+    expect(constructApiQueryParams(filters)).toEqual("")
+    expect(constructApiQueryParams(filtersTwo)).toEqual("")
   })
 })

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -7,3 +7,8 @@ export const PATHS = {
 export const SERVICE_TYPES = {
   AUTHN: "authn",
 }
+
+export const SUPPORTED_VERSIONS = {
+  FILTERING: "0.0.78-alpha.8",
+  EXTENSIONS: "0.0.79" // Version that supports browser extension redirects
+}

--- a/helpers/services.js
+++ b/helpers/services.js
@@ -35,13 +35,17 @@ export function filterOptInServices(services = [], includeList = []) {
   })
 }
 
-export const constructApiQueryParams = ({ include }) => {
-  let queryStr = '?'
+export const constructApiQueryParams = ({ version, include }) => {
+  let queryStr = ""
+
+  if (version) {
+    queryStr = queryStr.concat(`fcl_version=${version}&`)
+  }
   
   if (include) {
-    let includeQueryStr = include.map(addr => `include=${addr}`).join('&')
+    const includeQueryStr = include.map(addr => `include=${addr}`).join('&')
     queryStr = queryStr.concat(includeQueryStr)
   }
 
-  return queryStr
+  return queryStr.length ? `?${queryStr}` : ""
 }

--- a/pages/[...path].js
+++ b/pages/[...path].js
@@ -17,10 +17,10 @@ const AppContainer = styled.div`
 
 const Router = ({handleCancel}) => {
   const router = useRouter()
-  const {path, include} = router.query // path: ['authn'] ['testnet', 'authn'] ['canarynet', 'authn'] include: ['0x123']
+  const {path, fcl_version, include} = router.query // path: ['authn'] ['testnet', 'authn'] ['canarynet', 'authn'] include: ['0x123']
   const isValid = isValidPath(path)
   const network = getNetworkFromPath(path)
-  const queryStr = constructApiQueryParams({ include })
+  const queryStr = constructApiQueryParams({fcl_version, include})
 
   return (
     <AppContainer isSet={Boolean(path)}>


### PR DESCRIPTION
Support filtering for include only if fcl version is passed with route or request and it's greater or equal to supported version.