### PR TITLE
Fix unknown extension wallets not being displayed

### DIFF
--- a/helpers/__tests__/services.test.js
+++ b/helpers/__tests__/services.test.js
@@ -271,7 +271,7 @@ describe('services helpers: filterServicesByPlatform', () => {
     }
 
     const services = [serviceA, serviceB, serviceC]
-    const expectedRes = [serviceA, serviceC]
+    const expectedRes = [serviceA, serviceB, serviceC]
 
     expect(filterServicesByPlatform(platform, services)).toEqual(expectedRes)
   })
@@ -304,7 +304,7 @@ describe('services helpers: filterServicesByPlatform', () => {
     }
 
     const services = [serviceA, serviceB, serviceC]
-    const expectedRes = [serviceC]
+    const expectedRes = [serviceB, serviceC]
 
     expect(filterServicesByPlatform(platform, services)).toEqual(expectedRes)
   })

--- a/helpers/services.js
+++ b/helpers/services.js
@@ -77,6 +77,10 @@ export function filterServicesByPlatform(platform, services = []) {
     const providerMetadata = getProviderMetadataByAddress(
       service?.provider?.address
     )
+
+    // Assume it is supported if we can't find the metadata for it.
+    if (!providerMetadata) return true
+
     const providerPlatforms = Object.keys(providerMetadata?.platforms || {})
     return providerPlatforms.includes(platform?.toLowerCase())
   })


### PR DESCRIPTION
Fixes https://github.com/onflow/fcl-js/issues/1343

This PR simply makes it so that services with unknown metadata are automatically assumed to be supported by the platform.