### PR TITLE
Update Blocto wallet config to HTTP/POST

### DIFF
--- a/data/services.json
+++ b/data/services.json
@@ -4,9 +4,9 @@
       "f_type": "Service",
       "f_vsn": "1.0.0",
       "type": "authn",
-      "method": "IFRAME/RPC",
+      "method": "HTTP/POST",
       "uid": "blocto#authn",
-      "endpoint": "https://flow-wallet.blocto.app/authn",
+      "endpoint": "https://flow-wallet.blocto.app/api/flow/authn",
       "provider": {
         "address": "0x55ad22f01ef568a1",
         "name": "Blocto",
@@ -76,9 +76,9 @@
       "f_type": "Service",
       "f_vsn": "1.0.0",
       "type": "authn",
-      "method": "POP/RPC",
+      "method": "HTTP/POST",
       "uid": "blocto#authn",
-      "endpoint": "https://flow-wallet-testnet.blocto.app/authn",
+      "endpoint": "https://flow-wallet-testnet.blocto.app/api/flow/authn",
       "provider": {
         "address": "0xf086a545ce3c552d",
         "name": "Blocto",


### PR DESCRIPTION
Blocto is migrating wallet connection UI from `IFRAME` to `POP/TAB` soon. `HTTP/POST` is a preferred and more flexible connection method so we can let the dapps & FCL know which exact rendering method should be used now.