### PR TITLE
Add client config to wallet include

### DIFF
--- a/hooks/useFCL.js
+++ b/hooks/useFCL.js
@@ -37,7 +37,11 @@ export function useFCL() {
 
       if (appFclVersion) {
         setAppVersion(appFclVersion)
-        setWalletInclude(config.discoveryAuthnInclude || [])
+        setWalletInclude(
+          config?.discoveryAuthnInclude ||
+          config?.client?.discoveryAuthnInclude ||
+          []
+        )
       }
 
       if (services) {


### PR DESCRIPTION
`discoveryAuthnInclude` was moved to client config. This PR adds it keeping previous for backwards compatibility.