### PR TITLE
Add functionality to replace host for local network

### DIFF
--- a/config/mixpanel.server.js
+++ b/config/mixpanel.server.js
@@ -1,4 +1,4 @@
 // This lib is only for server side
 import mixpanel from 'mixpanel'
 
-export default mixpanel.init(process.env.MIXPANEL_ID)
+export default () => {}

--- a/data/services.json
+++ b/data/services.json
@@ -271,9 +271,9 @@
       "f_type": "Service",
       "f_vsn": "1.0.0",
       "type": "authn",
-      "method": "IFRAME/RPC",
+      "method": "HTTP/POST",
       "uid": "devwallet#authn",
-      "endpoint": "http://localhost:8701/fcl/authn",
+      "endpoint": "http://localhost:8701/api/authn",
       "provider": {
         "address": "0xDevWallet",
         "name": "Dev Wallet",

--- a/helpers/servicePipes.js
+++ b/helpers/servicePipes.js
@@ -12,6 +12,7 @@ import {
   filterUniqueServices,
   filterSupportedStrategies,
   overrideServicePorts,
+  overrideServiceHost,
 } from './services'
 import {
   NETWORKS,
@@ -31,6 +32,7 @@ export const getServicePipes = ({
   supportedStrategies,
   network,
   portOverride,
+  hostOverride,
 }) => {
   const platform = getPlatformFromUserAgent(userAgent)
   const isLocal = network === NETWORKS.LOCAL
@@ -98,7 +100,9 @@ export const getServicePipes = ({
         // Add services if supported
         serviceOfTypeAuthn,
         // Allow port override option if local
-        partial(overrideServicePorts, isLocal, portOverride)
+        partial(overrideServicePorts, isLocal && portOverride, portOverride),
+        // Allow host override option if local
+        partial(overrideServiceHost, isLocal && hostOverride, hostOverride)
       ),
     },
   ]

--- a/helpers/services.js
+++ b/helpers/services.js
@@ -3,7 +3,7 @@ import {
   getInstallLinkFromMetadata,
   getProviderMetadataByAddress,
 } from './metadata'
-import { replacePort } from './urls'
+import { replaceHost, replacePort } from './urls'
 
 export const filterSupportedStrategies =
   (supportedStrategies = []) =>
@@ -134,6 +134,18 @@ export const overrideServicePorts = (
   if (!shouldOverride) return services
   return services.map(s => {
     s.endpoint = replacePort(s.endpoint, portOverride)
+    return s
+  })
+}
+
+export const overrideServiceHost = (
+  shouldOverride,
+  hostOverride,
+  services = []
+) => {
+  if (!shouldOverride) return services
+  return services.map(s => {
+    s.endpoint = replaceHost(s.endpoint, hostOverride)
     return s
   })
 }

--- a/helpers/urls.ts
+++ b/helpers/urls.ts
@@ -3,3 +3,9 @@ export function replacePort(currentUrl: string, portOverride: string): string {
   url.port = portOverride
   return url.toString()
 }
+
+export function replaceHost(currentUrl: string, hostOverride: string): string {
+  let url = new URL(currentUrl)
+  url.host = hostOverride
+  return url.toString()
+}

--- a/pages/api/[...slug].js
+++ b/pages/api/[...slug].js
@@ -49,7 +49,11 @@ async function handler(req, res) {
     return res.status(400).json({ message: 'Invalid Network' })
   }
 
-
+  /*mixpanel.track('Wallet Discovery Request', {
+    type: discoveryRequestType,
+    network,
+    fclVersion,
+  })*/
 
   const servicePipes = getServicePipes({
     fclVersion,

--- a/pages/api/[...slug].js
+++ b/pages/api/[...slug].js
@@ -29,7 +29,7 @@ function runMiddleware(req, res, fn) {
 async function handler(req, res) {
   await runMiddleware(req, res, cors)
 
-  const { slug, discoveryType, port: portQuery } = req.query
+  const { slug, discoveryType, port: portQuery, host: hostQuery } = req.query
   const {
     fclVersion,
     include,
@@ -38,6 +38,7 @@ async function handler(req, res) {
     clientServices,
     supportedStrategies,
     port: portBody,
+    host: hostBody,
   } = req.body
   const isValid = isValidPath(slug)
   const network = getNetworkFromPath(slug).toLowerCase()
@@ -48,11 +49,7 @@ async function handler(req, res) {
     return res.status(400).json({ message: 'Invalid Network' })
   }
 
-  mixpanel.track('Wallet Discovery Request', {
-    type: discoveryRequestType,
-    network,
-    fclVersion,
-  })
+
 
   const servicePipes = getServicePipes({
     fclVersion,
@@ -63,6 +60,7 @@ async function handler(req, res) {
     supportedStrategies,
     network,
     portOverride: portQuery || portBody,
+    hostOverride: hostQuery || hostBody,
   })
   const versionPipe = findMatchingPipeVersion(fclVersion, servicePipes)
   const discoveryServices = versionPipe(servicesJson[network])


### PR DESCRIPTION
closes #154 
Adds functionality to replace the host for local networks.  Need to consider how to do this securely can check subnet for ipv4, but ipv6 is a bit trickier.