### PR TITLE
update to use local service config when network is emulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ fcl.config({
 | Mainnet     | `http://localhost:3002/authn` or `http://localhost:3002/mainnet/authn` |
 | Testnet     | `http://localhost:3002/testnet/authn`                                  |
 | Local       | `http://localhost:3002/local/authn`                                    |
+| Emulator    | `http://localhost:3002/emulator/authn`                                 |
 
 ### Discovery API Endpoints
 
@@ -42,8 +43,9 @@ fcl.config({
 | Mainnet     | `http://localhost:3002/api/authn` or `http://localhost:3002/api/mainnet/authn` |
 | Testnet     | `http://localhost:3002/api/testnet/authn`                                      |
 | Local       | `http://localhost:3002/api/local/authn`                                        |
+| Emulator    | `http://localhost:3002/api/emulator/authn`                                     |
 
-> Note: Local will return Dev Wallet as a service for developing locally with the default port of 8701. If you'd like to override the default port add ?port=0000 with the port being whatever you'd like to override it to.
+> Note: Local and emulator will return Dev Wallet as a service for developing locally with the default port of 8701. If you'd like to override the default port add ?port=0000 with the port being whatever you'd like to override it to.
 
 ## More Configuration
 

--- a/helpers/constants.js
+++ b/helpers/constants.js
@@ -1,6 +1,6 @@
 import Enum from 'enum-xyz'
 
-const {  AUTHN, CANARYNET, TESTNET, SANDBOXNET, MAINNET, LOCAL } = Enum.String({ casing: 'lowercase' })
+const {  AUTHN, CANARYNET, TESTNET, SANDBOXNET, MAINNET, LOCAL, EMULATOR } = Enum.String({ casing: 'lowercase' })
 
 export const NETWORKS = {
   CANARYNET, // canarynet
@@ -8,6 +8,7 @@ export const NETWORKS = {
   SANDBOXNET,
   MAINNET,
   LOCAL,
+  EMULATOR
 }
 
 export const SERVICE_TYPES = { AUTHN }
@@ -33,6 +34,7 @@ export const PATHS = {
   SANDBOXNET: '/sandboxnet/authn',
   CANARYNET: '/canarynet/authn',
   LOCAL: '/local/authn',
+  EMULATOR: '/emulator/authn',
 }
 
 export const SUPPORTED_VERSIONS = {

--- a/helpers/servicePipes.js
+++ b/helpers/servicePipes.js
@@ -33,7 +33,7 @@ export const getServicePipes = ({
   portOverride,
 }) => {
   const platform = getPlatformFromUserAgent(userAgent)
-  const isLocal = network === NETWORKS.LOCAL
+  const isLocal = network === NETWORKS.LOCAL || network === NETWORKS.EMULATOR
 
   // In newer versions, we'll have extensions sent
   // In older versions they were added on the FCL side

--- a/pages/api/[...slug].js
+++ b/pages/api/[...slug].js
@@ -6,6 +6,7 @@ import { findMatchingPipeVersion } from '../../helpers/version'
 import Sentry from '../../config/sentry.server'
 import mixpanel from '../../config/mixpanel.server'
 import { getServicePipes } from '../../helpers/servicePipes'
+import { NETWORKS } from '../../helpers/constants'
 
 // Initializing the cors middleware
 const cors = Cors({
@@ -65,7 +66,10 @@ async function handler(req, res) {
     portOverride: portQuery || portBody,
   })
   const versionPipe = findMatchingPipeVersion(fclVersion, servicePipes)
-  const discoveryServices = versionPipe(servicesJson[network])
+  
+  // support emulator and use local service configuration
+  const netConfig = network === NETWORKS.EMULATOR ? NETWORKS.LOCAL : network
+  const discoveryServices = versionPipe(servicesJson[netConfig])
 
   return res.status(200).json(discoveryServices)
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -15,6 +15,10 @@ export default function Home() {
           <strong>Local:</strong>{' '}
           https://fcl-discovery.onflow.org/api/local/authn
         </div>
+        <div>
+          <strong>Emulator:</strong>{' '}
+          https://fcl-discovery.onflow.org/api/emulator/authn
+        </div>
       </div>
     </div>
   )


### PR DESCRIPTION
closes: https://github.com/onflow/fcl-discovery/issues/172

Update to support emulator as a network, use local service config. This gives the user dev wallet to interact with the emulator.