### PR TITLE
Convert frontend to use `/api/wallets` route

### DIFF
--- a/components/GetWalletCard.tsx
+++ b/components/GetWalletCard.tsx
@@ -7,22 +7,19 @@ import {
   HStack,
   Image,
   Stack,
-  Tag,
   Text,
-  Link,
 } from '@chakra-ui/react'
-import { Service } from '../types'
 import NextLink from 'next/link'
+import { Wallet } from '../data/wallets'
 
 type Props = {
-  icon: string
-  name: string
-  service: Service
+  wallet: Wallet
 }
 
-export default function GetWalletCard({ icon, name, service }: Props) {
-  const isExtensionService = isExtension(service)
-  const isExtensionServiceInstalled = Boolean(service?.provider?.is_installed)
+export default function GetWalletCard({ wallet }: Props) {
+  const extensionService = wallet.services.find(isExtension)
+  const isExtensionService = !!extensionService
+  const isExtensionServiceInstalled = extensionService?.provider?.is_installed
 
   return (
     <Card size="md" variant="unstyled">
@@ -31,8 +28,8 @@ export default function GetWalletCard({ icon, name, service }: Props) {
           <Flex alignItems="center" justifyContent="space-between">
             <HStack>
               <Image
-                src={icon}
-                alt={name}
+                src={wallet.icon}
+                alt={wallet.name}
                 borderRadius="lg"
                 borderWidth="1px"
                 borderColor="gray.200"
@@ -43,7 +40,7 @@ export default function GetWalletCard({ icon, name, service }: Props) {
               />
               <Flex direction="column" textAlign="left">
                 <Text fontSize="lg" as="b">
-                  {name}
+                  {wallet.name}
                 </Text>
 
                 {isExtensionService && !isExtensionServiceInstalled ? (
@@ -58,7 +55,7 @@ export default function GetWalletCard({ icon, name, service }: Props) {
 
         {/* TODO: Needs to link to install page, will be addressed in future PR */}
         <Button
-          href={service.provider.install_link || service.provider.website}
+          href={wallet.website}
           target="_blank"
           as={NextLink}
           variant="outline"

--- a/components/GetWalletList.tsx
+++ b/components/GetWalletList.tsx
@@ -7,15 +7,8 @@ export default function GetWalletList() {
 
   return (
     <Stack spacing={4}>
-      {wallets.map((wallet, index) => {
-        return (
-          <GetWalletCard
-            key={wallet.provider.address ?? index}
-            service={wallet}
-            name={wallet?.provider?.name ?? ''}
-            icon={wallet?.provider?.icon ?? ''}
-          />
-        )
+      {wallets.map(wallet => {
+        return <GetWalletCard key={wallet.uid} wallet={wallet} />
       })}
     </Stack>
   )

--- a/components/ServiceCard.tsx
+++ b/components/ServiceCard.tsx
@@ -1,7 +1,4 @@
-import { WalletUtils } from '@onflow/fcl'
-import { SUPPORTED_VERSIONS } from '../helpers/constants'
 import { isExtension } from '../helpers/services'
-import { isGreaterThanOrEqualToVersion } from '../helpers/version'
 import {
   Card,
   CardBody,
@@ -12,47 +9,19 @@ import {
   Tag,
   Text,
 } from '@chakra-ui/react'
-import { Service } from '../types'
-import { useConfig } from '../contexts/ConfigContext'
-import { useLastUsedState } from '../hooks/useLastUsedState'
+import { Wallet } from '../data/wallets'
 
-type Props = {
-  icon: string
-  name: string
-  service: Service
+interface ServiceCardProps {
+  wallet: Wallet
 }
 
-export default function ServiceCard({ icon, name, service }: Props) {
-  const { appVersion } = useConfig()
-
-  const installLink = service?.provider?.install_link
-  const isExtensionService = isExtension(service)
-  const isExtensionServiceInstalled = Boolean(service?.provider?.is_installed)
-
-  const { setLastUsed } = useLastUsedState()
+export default function ServiceCard({ wallet }: ServiceCardProps) {
+  const extensionService = wallet.services.find(isExtension)
+  const isExtensionService = !!extensionService
+  const isExtensionServiceInstalled = extensionService?.provider?.is_installed
 
   const onSelect = () => {
-    if (!service) return
-
-    setLastUsed(service?.provider?.address)
-
-    if (isExtensionService && !isExtensionServiceInstalled) {
-      if (installLink) {
-        // Extensions require reload of page to inject script into dapp with data
-        // Redirecting dapp to install page forces page to be refreshed when returning
-        window.parent.location.href = installLink
-      }
-      return
-    }
-
-    if (
-      appVersion &&
-      isGreaterThanOrEqualToVersion(appVersion, SUPPORTED_VERSIONS.EXTENSIONS)
-    ) {
-      WalletUtils.redirect(service)
-    } else {
-      window.location.href = `${service.endpoint}${window.location.search}`
-    }
+    // TODO: implement connect wallet logic, future PR
   }
 
   return (
@@ -73,8 +42,8 @@ export default function ServiceCard({ icon, name, service }: Props) {
             <Flex alignItems="center" justifyContent="space-between">
               <HStack>
                 <Image
-                  src={icon}
-                  alt={name}
+                  src={wallet.icon}
+                  alt={wallet.name}
                   borderRadius="lg"
                   borderWidth="1px"
                   borderColor="gray.200"
@@ -85,7 +54,7 @@ export default function ServiceCard({ icon, name, service }: Props) {
                 />
                 <Flex direction="column" textAlign="left">
                   <Text fontSize="lg" as="b">
-                    {name}
+                    {wallet.name}
                   </Text>
 
                   {isExtensionService && !isExtensionServiceInstalled ? (

--- a/components/ServiceGroup.tsx
+++ b/components/ServiceGroup.tsx
@@ -1,17 +1,17 @@
-import { Flex, Stack, Text } from '@chakra-ui/react'
-import { Service } from '../types'
+import { Stack, Text } from '@chakra-ui/react'
 import ServiceCard from './ServiceCard'
+import { Wallet } from '../data/wallets'
 
 interface ServiceGroupProps {
   title: string
-  services: Service[]
+  wallets: Wallet[]
   titleProps?: React.ComponentProps<typeof Text>
   cardProps?: React.ComponentProps<typeof ServiceCard>
 }
 
 export default function ServiceGroup({
   title,
-  services,
+  wallets,
   titleProps,
   cardProps,
 }: ServiceGroupProps) {
@@ -21,16 +21,8 @@ export default function ServiceGroup({
         {title}
       </Text>
       <Stack spacing={2}>
-        {services.map((service, index) => {
-          return (
-            <ServiceCard
-              key={service?.provider?.address ?? index}
-              service={service}
-              name={service?.provider?.name ?? ''}
-              icon={service?.provider?.icon ?? ''}
-              {...cardProps}
-            />
-          )
+        {wallets.map(wallet => {
+          return <ServiceCard key={wallet.uid} wallet={wallet} {...cardProps} />
         })}
       </Stack>
     </Stack>

--- a/components/views/WalletSelection.tsx
+++ b/components/views/WalletSelection.tsx
@@ -35,7 +35,7 @@ export default function WalletSelection({ onSwitchToLearnMore }: Props) {
         <Stack overflow="scroll" px={8} pb={6} flexGrow={1}>
           {/* TODO: replace this in future PR with Filter Bar */}
           {/*isFeaturesSupported && <Features />*/}
-          <ServiceList services={wallets} />
+          <ServiceList wallets={wallets} />
         </Stack>
 
         <Divider color="gray.300" />

--- a/hooks/useLastUsedState.tsx
+++ b/hooks/useLastUsedState.tsx
@@ -1,9 +1,0 @@
-import { LOCAL_STORAGE_KEYS } from '../helpers/constants'
-import { useLocalStorage } from './useLocalStorage'
-
-export function useLastUsedState() {
-  const [, setLastUsed] = useLocalStorage(LOCAL_STORAGE_KEYS.LAST_USED, null)
-  const [lastUsed] = useLocalStorage(LOCAL_STORAGE_KEYS.LAST_USED, null)
-
-  return { lastUsed, setLastUsed }
-}

--- a/hooks/useWalletHistory.tsx
+++ b/hooks/useWalletHistory.tsx
@@ -1,0 +1,26 @@
+import { useCallback } from 'react'
+import { Wallet } from '../data/wallets'
+import { LOCAL_STORAGE_KEYS } from '../helpers/constants'
+import { useLocalStorage } from './useLocalStorage'
+
+export function useWalletHistory() {
+  const [, setLastUsedState] = useLocalStorage(
+    LOCAL_STORAGE_KEYS.LAST_USED,
+    null
+  )
+  const [lastUsedUid] = useLocalStorage(LOCAL_STORAGE_KEYS.LAST_USED, null)
+
+  const setLastUsed = useCallback(
+    (wallet: Wallet) => {
+      setLastUsedState(wallet.uid)
+    },
+    [setLastUsedState]
+  )
+
+  const isLastUsed = useCallback(
+    (wallet: Wallet) => wallet.uid === lastUsedUid,
+    [lastUsedUid]
+  )
+
+  return { isLastUsed, setLastUsed, lastUsedUid }
+}

--- a/hooks/useWallets.ts
+++ b/hooks/useWallets.ts
@@ -1,8 +1,7 @@
 import useSWR from 'swr'
-import { PATHS } from '../helpers/constants'
 import { useConfig } from '../contexts/ConfigContext'
 import { getUserAgent } from '../helpers/platform'
-import { Service } from '../types'
+import { Wallet } from '../data/wallets'
 
 const genKey = (url: string, opts: any) => [url, JSON.stringify(opts)]
 
@@ -27,7 +26,7 @@ export function useWallets() {
     port,
   } = useConfig()
 
-  const requestUrl = `/api${PATHS[network.toUpperCase()]}?discoveryType=UI`
+  const requestUrl = `/api/${network.toLowerCase()}/wallets?discoveryType=UI`
   const body = {
     type: ['authn'],
     fclVersion: appVersion,
@@ -43,7 +42,7 @@ export function useWallets() {
   }
 
   const { data: wallets, error } = useSWR(genKey(requestUrl, body), url =>
-    fetcher<Service[]>(url, body)
+    fetcher<Wallet[]>(url, body)
   )
 
   return { wallets, error, isLoading: !wallets && !error }


### PR DESCRIPTION
Closes #205 

Services of the same wallet are now joined into the same card:
<img width="502" alt="Screenshot 2024-07-25 at 12 31 50 PM" src="https://github.com/user-attachments/assets/686bd990-ac92-4d60-adbc-9c4d874281d1">

Clicking is now a NOOP, needs implementation in future PR