### PR TITLE
Fix collpased view flicker

### DIFF
--- a/hooks/useIsCollapsed.ts
+++ b/hooks/useIsCollapsed.ts
@@ -1,9 +1,18 @@
 import { useBreakpointValue } from '@chakra-ui/react'
+import { useDevice } from '../contexts/DeviceContext'
+import { DeviceType } from '../helpers/device'
 
 export function useIsCollapsed() {
+  const { deviceInfo } = useDevice()
   const isCollapsed = useBreakpointValue(
     { base: true, md: false },
-    { ssr: true, fallback: 'base' },
+    {
+      ssr: true,
+      fallback:
+        deviceInfo.type === DeviceType.MOBILE && !deviceInfo.isTablet
+          ? 'md'
+          : 'base',
+    },
   )
   return isCollapsed
 }


### PR DESCRIPTION
The SSR fallback was added before we had access to user agent parsing.

Now, we can default to something more sensible based on the user's device type.