### PR TITLE
Improve WalletConnect error message to distinguish errors with mobile vs desktop

### DIFF
--- a/components/views/ScanConnect/ScanConnectMobile.tsx
+++ b/components/views/ScanConnect/ScanConnectMobile.tsx
@@ -95,7 +95,7 @@ export default function ScanConnectMobile({
           spacing={2}
         >
           <Text textStyle="body2" colorScheme="red">
-            {`An error has occurred while generating the QR code. Please try again.`}
+            {`An error has occurred while connecting to your mobile wallet. Please try again.`}
           </Text>
         </Stack>
       )}


### PR DESCRIPTION
Updating this error message so it is easier to distinguish errors in mobile from errors in desktop. `ScanConnectMobile` does not use QR code.