### PR TITLE
Add timeout for mobile WalletConnect URI pre-loader

### DIFF
--- a/components/views/WalletSelection.tsx
+++ b/components/views/WalletSelection.tsx
@@ -69,6 +69,11 @@ const MobileWrapper = ({
   const { rpcEnabled } = useRpc()
   const shouldShowLoading = (wcUriLoading && rpcEnabled) || isLoading
 
+  // If the WC URI is still loading after 5 seconds, there is likely an issue
+  // with WalletConnect. The loading spinner will be disabled in order to prevent
+  // blocking the entire page. If the user proceeds to a mobile wallet and the WC URI
+  // happens to load, deep linking may not work as expected, but the user can still
+  // manually retry the connection.
   const [isTimedOut, setIsTimedOut] = useState(false)
   useEffect(() => {
     if (!wcUriLoading) {


### PR DESCRIPTION
closes #269 