### PR TITLE
Set Cross Origin Resource Policy to cross-origin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -49,6 +49,10 @@ const nextJsConfig = {
         source: '/:path*',
         headers: [
           {
+            key: 'Cross-Origin-Resource-Policy',
+            value: 'cross-origin',
+          },
+          {
             key: 'Cross-Origin-Embedder-Policy',
             value: 'credentialless',
           },


### PR DESCRIPTION
Currently FCL Discovery is blocked on sites that set a CORP, this will allow the iframe to be embedded on these sites.